### PR TITLE
Revert "bluetooth dedicated icons in notifications"

### DIFF
--- a/src/info-notification.vala
+++ b/src/info-notification.vala
@@ -82,14 +82,13 @@ public class IndicatorSound.InfoNotification: Notification
 		switch (active_output) {
 			case VolumeControl.ActiveOutput.SPEAKERS:
 			case VolumeControl.ActiveOutput.HEADPHONES:
+			case VolumeControl.ActiveOutput.BLUETOOTH_HEADPHONES:
+			case VolumeControl.ActiveOutput.BLUETOOTH_SPEAKER:
 			case VolumeControl.ActiveOutput.USB_SPEAKER:
 			case VolumeControl.ActiveOutput.USB_HEADPHONES:
 			case VolumeControl.ActiveOutput.HDMI_SPEAKER:
 			case VolumeControl.ActiveOutput.HDMI_HEADPHONES:
 				return "audio-volume-high";
-			case VolumeControl.ActiveOutput.BLUETOOTH_HEADPHONES:
-			case VolumeControl.ActiveOutput.BLUETOOTH_SPEAKER:
-				return "audio-speakers-bluetooth-symbolic";
 
 			default:
 				return "";


### PR DESCRIPTION
Reverts ubports/indicator-sound#4
soory @Flohack74 I made #4 because I couldn't compile `indicator-sound` with `crossbuilder` and @dobey suggested me to make a pr to make ubports ci compile it, but I forgot to close the pr or say it to you.
looking at the code it should work but after I tested this pr it seems there are no changes