### PR TITLE
use avaible suru icons

### DIFF
--- a/src/sound-menu.vala
+++ b/src/sound-menu.vala
@@ -121,8 +121,8 @@ public class SoundMenu: Object
 		set {
 			if (value && !this.mic_volume_shown) {
 				var slider = this.create_slider_menu_item (_("Microphone Volume"), "indicator.mic-volume", 0.0, 1.0, 0.01,
-														   "audio-input-microphone-symbolic",
-														   "audio-input-microphone-muted-symbolic", false);
+														   "audio-input-microphone-muted-symbolic",
+														   "audio-input-microphone-symbolic", false);
 				volume_section.append_item (slider);
 				this.mic_volume_shown = true;
 			}

--- a/src/sound-menu.vala
+++ b/src/sound-menu.vala
@@ -121,8 +121,8 @@ public class SoundMenu: Object
 		set {
 			if (value && !this.mic_volume_shown) {
 				var slider = this.create_slider_menu_item (_("Microphone Volume"), "indicator.mic-volume", 0.0, 1.0, 0.01,
-														   "audio-input-microphone-low-zero-panel",
-														   "audio-input-microphone-high-panel", false);
+														   "audio-input-microphone-symbolic",
+														   "audio-input-microphone-muted-symbolic", false);
 				volume_section.append_item (slider);
 				this.mic_volume_shown = true;
 			}


### PR DESCRIPTION
icons used were from another theme, this switches out to available suru icons

old icons with headset microphone attached:

![photo_2020-02-03_05-55-22](https://user-images.githubusercontent.com/1965279/73651304-c6cb7180-4649-11ea-9640-1142e16c79c1.jpg)

