### PR TITLE
Fix FTBFS due to tests for indicator-sound

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/sound-menu.vala
+++ b/src/sound-menu.vala
@@ -121,8 +121,8 @@ public class SoundMenu: Object
 		set {
 			if (value && !this.mic_volume_shown) {
 				var slider = this.create_slider_menu_item (_("Microphone Volume"), "indicator.mic-volume", 0.0, 1.0, 0.01,
-														   "audio-input-microphone-muted-symbolic",
-														   "audio-input-microphone-symbolic", false);
+														   "audio-input-microphone-low-zero-panel",
+														   "audio-input-microphone-high-panel", false);
 				volume_section.append_item (slider);
 				this.mic_volume_shown = true;
 			}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -74,25 +74,10 @@ target_link_libraries(
     gmenuharness-shared
 )
 
-####
-## When building under jenkins, pulseuadio fails to start as there is no
-## /run/user tree, HOME directory is missing, and similar issues. So here
-## we check that we are the jenkins user, and avoid the integration tests,
-## until such time in future when we can run these tests in some different
-## manner to avoid needing to run pulseaudio in this way.
-####
-execute_process(
-  COMMAND whoami
-  OUTPUT_VARIABLE TESTS_USER
-  OUTPUT_STRIP_TRAILING_WHITESPACE
+add_test(
+    integration-tests
+    integration-tests
 )
-
-if(NOT "${TESTS_USER}" STREQUAL "jenkins")
-  add_test(
-    integration-tests
-    integration-tests
-  )
-endif()
 
 set(
     SET-VOLUME-SRC


### PR DESCRIPTION
This requires 2 things:
- Make integration-test works under `HOME=/nonexistent` by providing a temporary HOME inside itself.
- Revert the attempt to fix the microphone icon. Turns out the cause isn't that the indicator provides the incorrect icon name, but rather that Unity8 uses the incorrect icon theme (!). As the fix also breaks the test, I decided to just revert it.

This PR comes with Jenkinsfile update. Requires https://github.com/ubports/qtmir/pull/55 to fully fix the microphone icons issue.

For QA: check that the sound indicator is working. If possible, plug a headset with a microphone and see if the microphone slider appears and has correct-looking icon.